### PR TITLE
Quote File.separator

### DIFF
--- a/extension/src/main/java/com/radcortez/flyway/test/junit/FlywayExtension.java
+++ b/extension/src/main/java/com/radcortez/flyway/test/junit/FlywayExtension.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
 import static java.io.File.separator;
@@ -51,7 +52,7 @@ public class FlywayExtension implements BeforeAllCallback, BeforeEachCallback, A
 
     private Flyway flyway(final FlywayTestConfiguration configuration, final ExtensionContext context) {
         final String packageName = context.getRequiredTestClass().getName();
-        final String testDefaultLocation = "db/" + packageName.replaceAll("\\.", separator);
+        final String testDefaultLocation = "db/" + packageName.replaceAll("\\.", Matcher.quoteReplacement(separator));
         final List<String> locations = new ArrayList<>(configuration.getLocations());
         locations.add(testDefaultLocation);
         locations.add("db" + separator + "migration");

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <!-- Examples -->
     <dependency.version.lombok>1.18.16</dependency.version.lombok>
-    <dependency.version.quarkus>1.10.3.Final</dependency.version.quarkus>
+    <dependency.version.quarkus>1.10.5.Final</dependency.version.quarkus>
     <dependency.version.spring>2.4.1</dependency.version.spring>
   </properties>
 


### PR DESCRIPTION
On Windows, File.separator('\') makes the replaceAll method failing with an IllegalArgumentException: character to be escaped is missing

Signed-off-by: Vincent Sourin <sourin-v@bridgestone-bae.com>