### PR TITLE
Fix URLs in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <name>Flyway JUnit5 - Parent</name>
   <description>Flyway JUnit5 Extension</description>
-  <url>https://radcortez.com/flyway-junit-extension</url>
+  <url>https://github.com/radcortez/flyway-junit5-extensions</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 
   <scm>
     <connection>scm:git:https://github.com/radcortez/flyway-junit5-extensions.git</connection>
-    <developerConnection>scm:git:https://github.com/radcortezx/flyway-junit5-extensions.git</developerConnection>
-    <url>scm:git:https://github.com/radcortez-tdx/flyway-junit5-extensions.git</url>
+    <developerConnection>scm:git:https://github.com/radcortez/flyway-junit5-extensions.git</developerConnection>
+    <url>scm:git:https://github.com/radcortez/flyway-junit5-extensions.git</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
I recently got an update PR from renovatebot ([example, but doesn't really matter](https://github.com/tim-hat-die-hand-an-der-maus/api/pull/22)), and noticed that it couldn't give me the release notes, and both the source URL and the project URL from the `pom.xml` are broken.

I'm not sure if anything is supposed to be at https://radcortez.com/flyway-junit-extension, but I just assumed there isn't and changed the URL to point to this repository as well.